### PR TITLE
[COOK-3972] When using chef-client::cron, allow the option to append output instead of overwriting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ The following attributes affect the behavior of the chef-client program when run
 * `node["chef_client"]["cron"]["use_cron_d"]` - If true, use the
   "cron_d" LWRP (https://github.com/opscode-cookbooks/cron). If false
   (default), use the cron resource built-in to Chef.
+* `node["chef_client"]["cron"]["append_log"]` - If true, the cron command
+  appends to `log_file`, rather than overwriting it. If false (default),
+  `log_file` is overwritten.
 * `node["chef_client"]["daemon_options"]` - An array of additional
   options to pass to the chef-client service, empty by default, and
   must be an array if specified.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,7 +49,8 @@ default["chef_client"]["cron"] = {
   "path" => nil,
   "environment_variables" => nil,
   "log_file" => "/dev/null",
-  "use_cron_d" => false
+  "use_cron_d" => false,
+  "append_log" => false
 }
 
 default["chef_client"]["load_gems"] = {}

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -72,6 +72,7 @@ checksum   = Digest::MD5.hexdigest(node['fqdn'] || 'unknown-hostname')
 sleep_time = checksum.to_s.hex % node['chef_client']['splay'].to_i
 env        = node['chef_client']['cron']['environment_variables']
 log_file   = node["chef_client"]["cron"]["log_file"]
+redirect_to = node['chef_client']['cron']['append_log'] ? '>>' : '>'
 
 # If "use_cron_d" is set to true, delete the cron entry that uses the cron
 # resource built in to Chef and instead use the cron_d LWRP.
@@ -85,7 +86,7 @@ if node['chef_client']['cron']['use_cron_d']
     hour    node['chef_client']['cron']['hour']
     path    node['chef_client']['cron']['path'] if node['chef_client']['cron']['path']
     user    "root"
-    command "/bin/sleep #{sleep_time}; #{env} #{client_bin} > #{log_file} 2>&1"
+    command "/bin/sleep #{sleep_time}; #{env} #{client_bin} #{redirect_to} #{log_file} 2>&1"
   end
 else
   cron_d "chef-client" do
@@ -97,6 +98,6 @@ else
     hour    node['chef_client']['cron']['hour']
     path    node['chef_client']['cron']['path'] if node['chef_client']['cron']['path']
     user    "root"
-    command "/bin/sleep #{sleep_time}; #{env} #{client_bin} > #{log_file} 2>&1"
+    command "/bin/sleep #{sleep_time}; #{env} #{client_bin} #{redirect_to} #{log_file} 2>&1"
   end
 end


### PR DESCRIPTION
The default of overwriting is preserved, but this is useful for CI
environments where a bad push might not get caught until well after the
fact (most importantly, after the next automated chef run, where
previous logs would be destroyed).

The actual impl is admittedly simple, and makes it slightly harder to
read; suggestions are welcome.

Jira ticket: https://tickets.opscode.com/browse/COOK-3972