### PR TITLE
handle nil client key

### DIFF
--- a/recipes/delete_validation.rb
+++ b/recipes/delete_validation.rb
@@ -22,9 +22,12 @@ class ::Chef::Recipe
 end
 
 unless chef_server?
+  # In some cases Chef::Config may not have a client_key
+  client_key = Chef::Config[:client_key] || '/etc/chef/validation.pem'
+
   file Chef::Config[:validation_key] do
     action :delete
     backup false
-    only_if { ::File.exists?(Chef::Config[:client_key]) }
+    only_if { ::File.exists?(client_key) }
   end
 end


### PR DESCRIPTION
In some work I was doing with packer and client-zero I ran into a case with a nil `Chef::Config[:client_key]`. This adds a default. I know this isn't proper for windows, maybe someone has input on the secret sauce for where the default should be on that platform. 

Tried to make an issue for this in tickets.opscode.com, but my login is wonked, and I can't reset it for whatever reason.