### PR TITLE
Handle verify_api_cert parameter by copying trusted certificate file to ...

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,6 +42,9 @@ default['chef_client']['splay']       = '300'
 default['chef_client']['conf_dir']    = '/etc/chef'
 default['chef_client']['bin']         = '/usr/bin/chef-client'
 
+default['chef_client']['trusted_certs_dir'] = "#{node['chef_client']['conf_dir']}/trusted_certs"
+default['chef_client']['trusted_cert'] = ""
+
 # Set a sane default log directory location, overriden by specific
 # platforms below.
 default['chef_client']['log_dir']     = '/var/log/chef'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@opscode.com'
 license           'Apache 2.0'
 description       'Manages client.rb configuration and chef-client service'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '3.7.0'
+version           '3.7.1'
 recipe 'chef-client', 'Includes the service recipe by default.'
 recipe 'chef-client::arch_service', 'Configures chef-client as a service on Arch Linux'
 recipe 'chef-client::bluepill_service', 'Configures chef-client as a service under Bluepill'

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -74,7 +74,7 @@ d_group = dir_group
 # If verify_api_cert is defined to be true, 
 # then we need Chef server certificate in trusted certificate directory
 #
-if node['chef_client']['config']['verify_api_cert'] == "true"
+if node['chef_client']['config']['verify_api_cert'] == true
   # If trusted certificate filename attribute is not defined
   # set verify_api_cert to false to prevent SSL certificate errors
   if node['chef_client']['trusted_cert'] != ""

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -70,6 +70,35 @@ end
 d_owner = dir_owner
 d_group = dir_group
 
+#
+# If verify_api_cert is defined to be true, 
+# then we need Chef server certificate in trusted certificate directory
+#
+if node['chef_client']['config']['verify_api_cert'] == "true"
+  # If trusted certificate filename attribute is not defined
+  # set verify_api_cert to false to prevent SSL certificate errors
+  if node['chef_client']['trusted_cert'] != ""
+    directory node['chef_client']['trusted_certs_dir'] do
+      recursive true
+      owner d_owner
+      group d_group
+      mode 00755
+    end
+    cert_filename= File.basename(node['chef_client']['trusted_cert'],".*")
+    remote_file "trusted_certificate" do
+      source "#{node['chef_client']['trusted_cert']}"
+      path "#{node['chef_client']['trusted_certs_dir']}/#{cert_filename}.crt"
+      owner d_owner
+      group d_group
+      mode 00644
+    end
+  else
+    Chef::Log.warn("Trusted certificate file is not defined, disabling Chef client configuration item 'verify_api_cert'")
+    node.override['chef_client']['config']['verify_api_cert'] = false
+    # So next block to fix client.rb will properly handle verify_api_cert parameter
+  end
+end
+
 template "#{node["chef_client"]["conf_dir"]}/client.rb" do
   source 'client.rb.erb'
   owner d_owner


### PR DESCRIPTION
Handle verify_api_cert parameter by copying trusted certificate file to client before client.rb is updated

Trusted certificates and verify_api_cert is handled with knife bootstrap command during initial bootstrap but for existing clients, this change will copy trusted certificate of Chef server from URI in node['chef_client']['trusted_cert'] to /etc/chef/trusted_certs directory if 
- verify_api_cert attribute is set to true and 
- node['chef_client']['trusted_cert'] attribute is not empty

If verify_api_cert is true and 'trusted_cert' attribute is not set, then in order not to break SSL communication, code will set verify_api_cert to false for that chef-client session. 
