### PR TITLE
correctly set "chef_server_user" for Chef Server 12

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -24,7 +24,11 @@ module Opscode
       include Chef::DSL::PlatformIntrospection if Chef::VERSION >= '11.0.0'
 
       def chef_server_user
-        Chef::VERSION >= '11.0.0' ? 'chef_server' : 'chef'
+        if Chef::VERSION >= '11.0.0'
+          system('getent passwd opscode') ? 'opscode' : 'chef_server'
+        else
+          'chef'
+        end
       end
 
       def chef_server?


### PR DESCRIPTION
Granted, this isn't the best solution, but Chef::VERSION was returning `11.x.x` because I am still using the 11.x version of chef-client.

This probably won't be merged, but at least others that want to setup Chef server 12 rc can use it for now.