### PR TITLE
Cleanup log location config in sysconfig/init scripts

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,7 @@ if Chef::Config.has_key?(:client_fork)
   default['chef_client']['config']['client_fork'] = true
 end
 
+# log_file has no effect when using runit
 default['chef_client']['log_file']    = 'client.log'
 default['chef_client']['interval']    = '1800'
 default['chef_client']['splay']       = '300'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,7 +36,7 @@ if Chef::Config.has_key?(:client_fork)
 end
 
 # By default, we don't have a log file, as we log to STDOUT
-default['chef_client']['log_file']    = nil
+default['chef_client']['log_file']    = 'client.log'
 default['chef_client']['interval']    = '1800'
 default['chef_client']['splay']       = '300'
 default['chef_client']['conf_dir']    = '/etc/chef'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,7 +35,6 @@ if Chef::Config.has_key?(:client_fork)
   default['chef_client']['config']['client_fork'] = true
 end
 
-# By default, we don't have a log file, as we log to STDOUT
 default['chef_client']['log_file']    = 'client.log'
 default['chef_client']['interval']    = '1800'
 default['chef_client']['splay']       = '300'

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -26,8 +26,8 @@ class ::Chef::Recipe
 end
 
 # chef_node_name = Chef::Config[:node_name] == node['fqdn'] ? false : Chef::Config[:node_name]
-case node['chef_client']['log_file']
-when String
+
+if node['chef_client']['log_file'].is_a? String and node['chef_client']['init_style'] != 'runit'
   log_path = File.join(node['chef_client']['log_dir'], node['chef_client']['log_file'])
   node.default['chef_client']['config']['log_location'] = "'#{log_path}'"
 

--- a/templates/arch/conf.d/chef-client.conf.erb
+++ b/templates/arch/conf.d/chef-client.conf.erb
@@ -1,4 +1,3 @@
-LOGFILE=<%= node["chef_client"]["log_dir"] %>/client.log
 CONFIG=<%= node["chef_client"]["conf_dir"] %>/client.rb
 INTERVAL=<%= node["chef_client"]["interval"] %>
 SPLAY=<%= node["chef_client"]["splay"] %>

--- a/templates/default/debian/default/chef-client.erb
+++ b/templates/default/debian/default/chef-client.erb
@@ -1,4 +1,3 @@
-LOGFILE=<%= node["chef_client"]["log_dir"] %>/client.log
 CONFIG=<%= node["chef_client"]["conf_dir"] %>/client.rb
 INTERVAL=<%= node["chef_client"]["interval"] %>
 SPLAY=<%= node["chef_client"]["splay"] %>

--- a/templates/default/debian/init.d/chef-client.erb
+++ b/templates/default/debian/init.d/chef-client.erb
@@ -32,10 +32,6 @@ fi
 
 DAEMON_OPTS="-d -P $PIDFILE -c $CONFIG -i $INTERVAL -s $SPLAY <%= node["chef_client"]["daemon_options"].join(' ') %>"
 
-if [ ! -z $LOGFILE ]; then
-  DAEMON_OPTS="${DAEMON_OPTS} -L $LOGFILE"
-fi
-
 running_pid() {
   pid=$1
   name=$2

--- a/templates/default/debian/init/chef-client.conf.erb
+++ b/templates/default/debian/init/chef-client.conf.erb
@@ -19,5 +19,5 @@ script
         . /etc/default/locale
         export LANG LANGUAGE LC_MESSAGES LC_ALL
     fi
-    exec <%= @client_bin %> -i <%= node["chef_client"]["interval"] %> -L <%= node["chef_client"]["log_dir"] %>/client.log <%= node["chef_client"]["daemon_options"].join(' ') %>
+    exec <%= @client_bin %> -i <%= node["chef_client"]["interval"] %> <%= node["chef_client"]["daemon_options"].join(' ') %>
 end script

--- a/templates/default/fedora/sysconfig/chef-client.erb
+++ b/templates/default/fedora/sysconfig/chef-client.erb
@@ -3,7 +3,6 @@
 CONFIG=<%= node["chef_client"]["conf_dir"] %>/client.rb
 PIDFILE=<%= node["chef_client"]["run_path"] %>/client.pid
 #LOCKFILE=/var/lock/subsys/chef-client
-LOGFILE=<%= node["chef_client"]["log_dir"] %>/client.log
 # Sleep interval between runs.
 # This value is in seconds.
 INTERVAL=<%= node["chef_client"]["interval"] %>

--- a/templates/default/redhat/init.d/chef-client.erb
+++ b/templates/default/redhat/init.d/chef-client.erb
@@ -26,7 +26,6 @@ prog="chef-client"
 config=${CONFIG-/etc/chef/client.rb}
 pidfile=${PIDFILE-/var/run/chef/client.pid}
 lockfile=${LOCKFILE-/var/lock/subsys/$prog}
-logfile=${LOGFILE-/var/log/chef/client.log}
 interval=${INTERVAL-1800}
 splay=${SPLAY-20}
 options=${OPTIONS-}
@@ -35,7 +34,7 @@ start() {
     [ -x $exec ] || exit 5
     [ -f $config ] || exit 6
     echo -n $"Starting $prog: "
-    daemon $exec -d -c "$config" -L "$logfile" -P "$pidfile" -i "$interval" -s "$splay" "$options"
+    daemon $exec -d -c "$config" -P "$pidfile" -i "$interval" -s "$splay" "$options"
     retval=$?
     echo
     [ $retval -eq 0 ] && touch $lockfile

--- a/templates/default/redhat/sysconfig/chef-client.erb
+++ b/templates/default/redhat/sysconfig/chef-client.erb
@@ -3,7 +3,6 @@
 CONFIG=<%= node["chef_client"]["conf_dir"] %>/client.rb
 PIDFILE=<%= node["chef_client"]["run_path"] %>/client.pid
 #LOCKFILE=/var/lock/subsys/chef-client
-LOGFILE=<%= node["chef_client"]["log_dir"] %>/client.log
 # Sleep interval between runs.
 # This value is in seconds.
 INTERVAL=<%= node["chef_client"]["interval"] %>

--- a/templates/default/solaris/chef-client.erb
+++ b/templates/default/solaris/chef-client.erb
@@ -40,12 +40,11 @@ DAEMON=<%= node["chef_client"]["bin_dir"] %>/chef-client
 NAME=chef-client
 DESC=chef-client
 PIDFILE=<%= node["chef_client"]["run_path"] %>/client.pid
-LOGFILE=<%= node["chef_client"]["log_dir"] %>/client.log
 CONFIG=<%= node["chef_client"]["conf_dir"] %>/client.rb
 INTERVAL=<%= node["chef_client"]["interval"] %>
 SPLAY=<%= node["chef_client"]["splay"] %>
 
-DAEMON_OPTS="-d -P $PIDFILE -L $LOGFILE -c $CONFIG -i $INTERVAL -s $SPLAY <%= node["chef_client"]["daemon_options"].join(' ') %>"
+DAEMON_OPTS="-d -P $PIDFILE -c $CONFIG -i $INTERVAL -s $SPLAY <%= node["chef_client"]["daemon_options"].join(' ') %>"
 
 if [ ! -d <%= node["chef_client"]["run_path"] %> ]; then
   mkdir <%= node["chef_client"]["run_path"] %>

--- a/templates/default/suse/init.d/chef-client.erb
+++ b/templates/default/suse/init.d/chef-client.erb
@@ -27,7 +27,6 @@ fi
 CONFIG=${CONFIG-<%= node["chef_client"]["conf_dir"] %>/client.rb}
 PIDFILE=${PIDFILE-<%= node["chef_client"]["run_dir"] %>/client.pid}
 LOCKFILE=${LOCKFILE-/var/lock/subsys/chef-client}
-LOGFILE=${LOGFILE-<%= node["chef_client"]["log_dir"] %>/client.log}
 INTERVAL=${INTERVAL-<%= node["chef_client"]["interval"] %>}
 SPLAY=${SPLAY-<%= node["chef_client"]["splay"] %>}
 OPTIONS=${OPTIONS-}
@@ -76,7 +75,7 @@ case "$1" in
         echo -n "Starting chef-client "
         ## Start daemon with startproc(8). If this fails
         ## the return value is set appropriately by startproc.
-        /sbin/startproc -p $PIDFILE $CHEF_CLIENT -d -c "$CONFIG" -L "$LOGFILE" -P "$PIDFILE" -i "$INTERVAL" -s "$SPLAY" "$OPTIONS"
+        /sbin/startproc -p $PIDFILE $CHEF_CLIENT -d -c "$CONFIG" -P "$PIDFILE" -i "$INTERVAL" -s "$SPLAY" "$OPTIONS"
 
         # Remember status and be verbose
         rc_status -v

--- a/templates/default/suse/sysconfig/chef-client.erb
+++ b/templates/default/suse/sysconfig/chef-client.erb
@@ -3,7 +3,6 @@
 CONFIG=<%= node["chef_client"]["conf_dir"] %>/client.rb
 PIDFILE=<%= node["chef_client"]["run_path"] %>/client.pid
 #LOCKFILE=/var/lock/subsys/chef-client
-LOGFILE=<%= node["chef_client"]["log_dir"] %>/client.log
 # Sleep interval between runs.
 # This value is in seconds.
 INTERVAL=<%= node["chef_client"]["interval"] %>

--- a/templates/freebsd/chef-client.erb
+++ b/templates/freebsd/chef-client.erb
@@ -10,6 +10,6 @@ name="chef"
 pidfile="<%= node["chef_client"]["run_path"] %>/${name}.pid"
 command="<%= @client_bin %>"
 command_interpreter="<%= RbConfig.ruby %>"
-command_args="-i <%= node["chef_client"]["interval"] %> -s <%= node["chef_client"]["splay"] %> -d -L <%= node["chef_client"]["log_dir"] %>/client.log -P <%= node["chef_client"]["run_path"] %>/${name}.pid"
+command_args="-i <%= node["chef_client"]["interval"] %> -s <%= node["chef_client"]["splay"] %> -d -P <%= node["chef_client"]["run_path"] %>/${name}.pid"
 load_rc_config $name
 run_rc_command "$1"

--- a/templates/windows/chef-client.xml.erb
+++ b/templates/windows/chef-client.xml.erb
@@ -32,7 +32,7 @@ THE SOFTWARE.
   <name>Chef-client Service for Windows</name>
   <description>This service runs chef-client. Configuration of this service is managed by the chef-client cookbook.</description>
   <executable><%= node["chef_client"]["ruby_bin"] %></executable>
-  <arguments><%= node["chef_client"]["bin"] %> -L "<%= File.join(node["chef_client"]["log_dir"], "client.log") %>" -c "<%= File.join(node["chef_client"]["conf_dir"], "client.rb") %>" -i <%= node["chef_client"]["interval"] %> -s <%= node["chef_client"]["splay"] %> <%= node["chef_client"]["daemon_options"].join(' ') %></arguments>
+  <arguments><%= node["chef_client"]["bin"] %> -c "<%= File.join(node["chef_client"]["conf_dir"], "client.rb") %>" -i <%= node["chef_client"]["interval"] %> -s <%= node["chef_client"]["splay"] %> <%= node["chef_client"]["daemon_options"].join(' ') %></arguments>
   <logmode>rotate</logmode>
   <logpath><%= node["chef_client"]["log_dir"] %></logpath>
 </service>


### PR DESCRIPTION
Set log_file default to client.log (nobody would log in stdout when running chef-client as a service IMO).

Remove all references to LOG_LOCATION in sysconfig/init scripts since client.rb config file will set it.

It should make configuration clearer and allow users to set log_location in client.d/something.rb without having to fight againts init scripts.

This can replaces #163 