### PR TITLE
ignore empty strings in the client.rb file

### DIFF
--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -116,6 +116,30 @@ describe 'chef-client::config' do
       expect(template).to_not notify('ruby_block[reload_client_config]')
     end
 
+    context 'empty config key values' do
+      let(:chef_run) do
+        ChefSpec::Runner.new do |node|
+          node.set['chef_client']['config']['http_proxy'] = ''
+          node.set['chef_client']['config']['https_proxy'] = ''
+          node.set['chef_client']['config']['no_proxy'] = ''
+        end.converge(described_recipe)
+      end
+
+      it 'does not write config elements' do
+        expect(chef_run).to_not render_file('/etc/chef/client.rb') \
+        .with_content(%r{^https_proxy ""})
+
+        expect(chef_run).to_not render_file('/etc/chef/client.rb') \
+        .with_content(%r{^ENV\['HTTPS_PROXY'\] = ""})
+
+        expect(chef_run).to_not render_file('/etc/chef/client.rb') \
+        .with_content(%r{^ENV\['HTTP_PROXY'\] = ""})
+
+        expect(chef_run).to_not render_file('/etc/chef/client.rb') \
+        .with_content(%r{^ENV\['NO_PROXY'\] = ""})
+      end
+    end
+
   end
 
 

--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -10,6 +10,7 @@ end
 <% end -%>
 <% @chef_config.keys.sort.each do |option| -%>
   <% next if %w{ node_name exception_handlers report_handlers start_handlers }.include?(option) -%>
+  <% next if @chef_config[option].is_a?(String) && @chef_config[option].empty? -%>
   <% case option -%>
   <% when 'log_level', 'ssl_verify_mode' -%>
 <%= option %> <%= @chef_config[option].gsub(/^:/, '').to_sym.inspect %>
@@ -24,19 +25,18 @@ node_name <%= @chef_config['node_name'].inspect %>
 <% else -%>
 # Using default node name (fqdn)
 <% end -%>
-<% unless node["chef_client"]["config"]["http_proxy"].nil? -%>
-
+<% unless @chef_config["http_proxy"].nil? || @chef_config["http_proxy"].empty? -%>
 # set the proxy env variable so rubygems works correctly
-ENV['http_proxy'] = "<%= node["chef_client"]["config"]["http_proxy"] %>"
-ENV['HTTP_PROXY'] = "<%= node["chef_client"]["config"]["http_proxy"] %>"
+ENV['http_proxy'] = "<%= @chef_config["http_proxy"] %>"
+ENV['HTTP_PROXY'] = "<%= @chef_config["http_proxy"] %>"
 <% end -%>
-<% unless node["chef_client"]["config"]["https_proxy"].nil? -%>
-ENV['https_proxy'] = "<%= node["chef_client"]["config"]["https_proxy"] %>"
-ENV['HTTPS_PROXY'] = "<%= node["chef_client"]["config"]["https_proxy"] %>"
+<% unless @chef_config["https_proxy"].nil? || @chef_config["https_proxy"].empty? -%>
+ENV['https_proxy'] = "<%= @chef_config["https_proxy"] %>"
+ENV['HTTPS_PROXY'] = "<%= @chef_config["https_proxy"] %>"
 <% end -%>
-<% unless node["chef_client"]["config"]["no_proxy"].nil? -%>
-ENV['no_proxy'] = "<%= node["chef_client"]["config"]["no_proxy"] %>"
-ENV['NO_PROXY'] = "<%= node["chef_client"]["config"]["no_proxy"] %>"
+<% unless @chef_config["no_proxy"].nil? || @chef_config["no_proxy"].empty? -%>
+ENV['no_proxy'] = "<%= @chef_config["no_proxy"] %>"
+ENV['NO_PROXY'] = "<%= @chef_config["no_proxy"] %>"
 <% end -%>
 
 <% if node.attribute?("ohai") && node["ohai"].attribute?("plugin_path") -%>


### PR DESCRIPTION
This PR is has couple loosely related objecives.

In an environments where *almost* all your nodes use a proxy server, you might set your proxy configuration in your base role or environment file. You then realize having your proxy servers configured to use themselves as proxy servers may not be ideal.... The logical solution is to set an attribute override to wipe out the default that you setting. Sadly if you try that (like I did), you run into the fact that setting a nil value in an override doesn't actually work: https://github.com/opscode/chef/issues/1507

No problem, I'll set the values to an empty string... Sadly that results in the values getting written to the client.rb as an empty string:(

Inspired by this https://github.com/miketheman/nginx/commit/b21cb4ed14578185f4479ce195f986f8f783aff0 this PR will update the client.rb template to not write out configuration elements that are not empty strings. I couldn't think of any situation where it would be valid do to so, but I admit, its not impossible there could be one. We then take that some approach for the proxy ENV vars, and don't write them out if the strings are empty.

The last update to the template is to use the `@chef_config` when evaluating the proxy settings rather than the node attribute. This is for consistency more than anything else. The `@chef_config` already has the data that was passed in, so we can access the config in a uniform fashion.

Lastly, a new test context for ensuring the empty strings don't get written out.
