### PR TITLE
Move windows service log to logs directory

### DIFF
--- a/recipes/windows_service.rb
+++ b/recipes/windows_service.rb
@@ -30,7 +30,7 @@ end
 create_directories
 
 execute 'register-chef-service' do
-  command 'chef-service-manager -a install'
+  command "chef-service-manager -a install -L #{File.join(node['chef_client']['log_dir'], 'client.log')}"
   not_if { chef_client_service_running }
 end
 


### PR DESCRIPTION
The current chef-service-manager command causes windows logs to be placed into c:\chef\chef-client.log (which is fine default to match documentation at https://docs.chef.io/install_windows.html#run-as-a-service)

This is a little strange though given that a c:\chef\logs directory is created by the chef-client cookbook and the default ['chef-client']['log_dir'] is c:\chef\logs. I propose that the default log location be moved to that directory.

Alternatively, even if the current c:\chef\client.log file is kept, I think it would be valuable to make the location configurable via an attribute.