### PR TITLE
Clean up test harness

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,13 +8,14 @@ platforms:
   - name: centos-5.11
   - name: centos-6.6
   - name: centos-7.0
-  - name: fedora-19
+  - name: debian-7.7
   - name: fedora-20
+  - name: fedora-21
   - name: freebsd-9.3
   - name: freebsd-10.1
-  - name: ubuntu-1004
-  - name: ubuntu-1204
-  - name: ubuntu-1404
+  - name: ubuntu-10.04
+  - name: ubuntu-12.04
+  - name: ubuntu-14.04
 
 suites:
 
@@ -30,7 +31,7 @@ suites:
   - recipe[chef-client::config]
   - recipe[chef-client::init_service]
   attributes: {}
-  excludes: ["centos-7.0", "fedora-19", "fedora-20"]
+  excludes: ["centos-7.0", "fedora-20", "fedora-21"]
 
 - name: service_runit
   run_list:
@@ -42,7 +43,7 @@ suites:
   run_list:
   - recipe[chef-client::systemd_service]
   attributes: {}
-  includes: ["centos-7.0", "fedora-19", "fedora-20"]
+  includes: ["centos-7.0", "fedora-20", "fedora-21"]
 
 - name: service_upstart
   run_list:


### PR DESCRIPTION
- Remove Fedora 19; it is EOL in 5 days
- Added Debian 7.7
- Ubuntu platforms were missing a decimal point so they couldn't actually be tested.