### PR TITLE
http_proxy, https_proxy & no_proxy options to set ENV variables

### DIFF
--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -30,7 +30,7 @@ node_name <%= @chef_config['node_name'].inspect %>
 http_proxy "<%= node["chef_client"]["config"]["http_proxy"] %>"
 <% end -%>
 <% unless node["chef_client"]["config"]["https_proxy"].nil? -%>
-https_proxy = "<%= node["chef_client"]["config"]["https_proxy"] %>"
+https_proxy "<%= node["chef_client"]["config"]["https_proxy"] %>"
 <% end -%>
 <% unless node["chef_client"]["config"]["no_proxy"].nil? -%>
 no_proxy "<%= node["chef_client"]["config"]["no_proxy"] %>"

--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -24,19 +24,16 @@ node_name <%= @chef_config['node_name'].inspect %>
 <% else -%>
 # Using default node name (fqdn)
 <% end -%>
-<% unless node["chef_client"]["config"]["http_proxy"].nil? -%>
 
+<% unless node["chef_client"]["config"]["http_proxy"].nil? -%>
 # set the proxy env variable so rubygems works correctly
-ENV['http_proxy'] = "<%= node["chef_client"]["config"]["http_proxy"] %>"
-ENV['HTTP_PROXY'] = "<%= node["chef_client"]["config"]["http_proxy"] %>"
+http_proxy "<%= node["chef_client"]["config"]["http_proxy"] %>"
 <% end -%>
 <% unless node["chef_client"]["config"]["https_proxy"].nil? -%>
-ENV['https_proxy'] = "<%= node["chef_client"]["config"]["https_proxy"] %>"
-ENV['HTTPS_PROXY'] = "<%= node["chef_client"]["config"]["https_proxy"] %>"
+https_proxy = "<%= node["chef_client"]["config"]["https_proxy"] %>"
 <% end -%>
 <% unless node["chef_client"]["config"]["no_proxy"].nil? -%>
-ENV['no_proxy'] = "<%= node["chef_client"]["config"]["no_proxy"] %>"
-ENV['NO_PROXY'] = "<%= node["chef_client"]["config"]["no_proxy"] %>"
+no_proxy "<%= node["chef_client"]["config"]["no_proxy"] %>"
 <% end -%>
 
 <% if node.attribute?("ohai") && node["ohai"].attribute?("plugin_path") -%>


### PR DESCRIPTION
There is no need to set ENV variables in the client.rb, instead they are standard options.
This might be a new change to the config and this cookbook doesn't install a specific version of chef-client, so I am unsure if instead i should put some logic in here?

Obvious fix.