### PR TITLE
Configure logrotate to use systemd when appropriate in chef-client::config recipe.

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -38,11 +38,12 @@ if node['chef_client']['log_file'].is_a? String and node['chef_client']['init_st
       rotate node['chef_client']['logrotate']['rotate']
       frequency node['chef_client']['logrotate']['frequency']
       options ['compress']
-      if node['chef_client']['init_style'] == 'systemd'
-        postrotate 'systemctl reload chef-client.service >/dev/null || :'
-      else
-        postrotate '/etc/init.d/chef-client reload >/dev/null || :'
-      end
+      postrotate case node['chef_client']['init_style']
+                 when 'systemd'
+                   'systemctl reload chef-client.service >/dev/null || :'
+                 else
+                   '/etc/init.d/chef-client reload >/dev/null || :'
+                 end
     end
   end
 else

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -38,7 +38,11 @@ if node['chef_client']['log_file'].is_a? String and node['chef_client']['init_st
       rotate node['chef_client']['logrotate']['rotate']
       frequency node['chef_client']['logrotate']['frequency']
       options ['compress']
-      postrotate '/etc/init.d/chef-client reload >/dev/null || :'
+      if node['chef_client']['init_style'] == 'systemd'
+        postrotate 'systemctl reload chef-client.service >/dev/null || :'
+      else
+        postrotate '/etc/init.d/chef-client reload >/dev/null || :'
+      end
     end
   end
 else


### PR DESCRIPTION
This fixes a bug on Centos 7 where logrotate was trying to use a nonexistant `/etc/init.d/chef-client` script on a `systemd` system.