### PR TITLE
Verify API certs by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,10 +1,10 @@
 #
-# Author:: Joshua Timberman (<joshua@opscode.com>)
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
-# Cookbook Name:: chef
+# Author:: Joshua Timberman (<joshua@chef.io>)
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Cookbook Name:: chef-client
 # Attributes:: default
 #
-# Copyright 2008-2011, Opscode, Inc
+# Copyright 2008-2015, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,8 @@ require 'rbconfig'
 default['chef_client']['config'] = {
   'chef_server_url' => Chef::Config[:chef_server_url],
   'validation_client_name' => Chef::Config[:validation_client_name],
-  'node_name' => Chef::Config[:node_name] == node['fqdn'] ? false : Chef::Config[:node_name]
+  'node_name' => Chef::Config[:node_name] == node['fqdn'] ? false : Chef::Config[:node_name],
+  'verify_api_cert' => true
 }
 
 if Chef::Config.has_key?(:client_fork)
@@ -170,8 +171,4 @@ else
   default['chef_client']['run_path']    = '/var/run'
   default['chef_client']['cache_path']  = '/var/chef/cache'
   default['chef_client']['backup_path'] = '/var/chef/backup'
-end
-
-if %r{^https://api.opscode.com/}.match(node['chef_client']['config']['chef_server_url'])
-  default['chef_client']['config']['verify_api_cert'] = true
 end


### PR DESCRIPTION
This is best practice, so force users to turn it off if they're really sure they don't want this.