### PR TITLE
Remove logic pertaining to checking whether this is a Chef Server.

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -23,21 +23,6 @@ module Opscode
       include Chef::Mixin::Language if Chef::VERSION < '11.0.0'
       include Chef::DSL::PlatformIntrospection if Chef::VERSION >= '11.0.0'
 
-      def chef_server_user
-        Chef::VERSION >= '11.0.0' ? 'chef_server' : 'chef'
-      end
-
-      def chef_server?
-        if node['platform'] == 'windows'
-          node.recipe?('chef-server')
-        else
-          Chef::Log.debug("Node has Chef Server Recipe? #{node.recipe?("chef-server")}")
-          Chef::Log.debug("Node has Chef Server Executable? #{system("which chef-server > /dev/null 2>&1")}") # ~FC048 Prefer Mixlib::ShellOut is ignored here
-          Chef::Log.debug("Node has Chef Server Ctl Executable? #{system("which chef-server-ctl > /dev/null 2>&1")}") # ~FC048 Prefer Mixlib::ShellOut is ignored here
-          node.recipe?('chef-server') || system('which chef-server > /dev/null 2>&1') || system('which chef-server-ctl > /dev/null 2>&1') # ~FC048 Prefer Mixlib::ShellOut is ignored here
-        end
-      end
-
       def wmi_property_from_query(wmi_property, wmi_query)
         @wmi = ::WIN32OLE.connect("winmgmts://")
         result = @wmi.ExecQuery(wmi_query)
@@ -57,38 +42,9 @@ module Opscode
         end
       end
 
-      def dir_owner
-        if chef_server?
-          chef_server_user
-        else
-          root_owner
-        end
-      end
-
-      def root_group
-        if %w{ openbsd freebsd mac_os_x mac_os_x_server }.include?(node['platform'])
-          'wheel'
-        elsif ['aix'].include?(node['platform'])
-          'system'
-        elsif ['windows'].include?(node['platform'])
-          wmi_property_from_query(:name, "select * from Win32_Group where SID = 'S-1-5-32-544' AND LocalAccount=TRUE")
-        else
-          'root'
-        end
-      end
-
-      def dir_group
-        if chef_server?
-          chef_server_user
-        else
-          root_group
-        end
-      end
-
       def create_directories
-        # dir_owner and dir_group are not found in the block below.
-        d_owner = dir_owner
-        d_group = dir_group
+        # root_owner is not in scope in the block below.
+        d_owner = root_owner
         %w{run_path cache_path backup_path log_dir conf_dir}.each do |dir|
           # Do not redefine the resource if it exist
           begin
@@ -98,7 +54,7 @@ module Opscode
               recursive true
               mode 00750 if dir == 'log_dir'
               owner d_owner
-              group d_group
+              group node['root_group']
             end
           end
         end

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -67,8 +67,8 @@ end
 
 # We need to set these local variables because the methods aren't
 # available in the Chef::Resource scope
-d_owner = dir_owner
-d_group = dir_group
+d_owner = root_owner
+d_group = node['root_group']
 
 template "#{node["chef_client"]["conf_dir"]}/client.rb" do
   source 'client.rb.erb'

--- a/recipes/delete_validation.rb
+++ b/recipes/delete_validation.rb
@@ -21,10 +21,8 @@ class ::Chef::Recipe
   include ::Opscode::ChefClient::Helpers
 end
 
-unless chef_server?
-  file Chef::Config[:validation_key] do
-    action :delete
-    backup false
-    only_if { ::File.exists?(Chef::Config[:client_key]) }
-  end
+file Chef::Config[:validation_key] do
+  action :delete
+  backup false
+  only_if { ::File.exists?(Chef::Config[:client_key]) }
 end


### PR DESCRIPTION
:construction: 

My suspicion is that this stuff is legacy from the days when this was the `chef` cookbook, rather than the `chef-client` cookbook. Does anyone know of a good reason why we might need to keep any of this?

/cc @jtimberman @afiune 