### PR TITLE
Include environment in client.rb if provided in bootstrap configs

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,6 +28,7 @@ require 'rbconfig'
 default['chef_client']['config'] = {
   'chef_server_url' => Chef::Config[:chef_server_url],
   'validation_client_name' => Chef::Config[:validation_client_name],
+  'environment' => Chef::Config[:environment] == '_default' ? false : Chef::Config[:environment],
   'node_name' => Chef::Config[:node_name] == node['fqdn'] ? false : Chef::Config[:node_name],
   'verify_api_cert' => true
 }

--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -9,7 +9,7 @@ end
 
 <% end -%>
 <% @chef_config.keys.sort.each do |option| -%>
-  <% next if %w{ node_name exception_handlers report_handlers start_handlers }.include?(option) -%>
+  <% next if %w{ node_name environment exception_handlers report_handlers start_handlers }.include?(option) -%>
   <% case option -%>
   <% when 'log_level', 'ssl_verify_mode' -%>
 <%= option %> <%= @chef_config[option].gsub(/^:/, '').to_sym.inspect %>
@@ -19,6 +19,9 @@ end
 <%= option %> <%= @chef_config[option].inspect %>
   <% end -%>
 <% end -%>
+<% if @chef_config['environment'] -%>
+environment <%= @chef_config['environment'].inspect %>
+<%end -%>
 <% if @chef_config['node_name'] -%>
 node_name <%= @chef_config['node_name'].inspect %>
 <% else -%>


### PR DESCRIPTION
Pull request to address #262. 

Allows a bootstrap'd chef environment to be automatically included in the generated client.rb when chef-client is installed, similar to chef_server_url, validation_client_name etc...

This seems to have been implied by the README, but not yet implemented.