### PR TITLE
Do not duplicate proxy configuration

### DIFF
--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -9,7 +9,7 @@ end
 
 <% end -%>
 <% @chef_config.keys.sort.each do |option| -%>
-  <% next if %w{ node_name environment exception_handlers report_handlers start_handlers }.include?(option) -%>
+  <% next if %w{ node_name environment exception_handlers report_handlers start_handlers http_proxy https_proxy no_proxy }.include?(option) -%>
   <% case option -%>
   <% when 'log_level', 'ssl_verify_mode' -%>
 <%= option %> <%= @chef_config[option].gsub(/^:/, '').to_sym.inspect %>


### PR DESCRIPTION
Added http_proxy, https_proxy and no_proxy options to the ignore list, else they get duplicated in #{node["chef_client"]["conf_dir"]}/client.rb.
See lines 31-40.