### PR TITLE
Enable changing of permissions for log directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The following attributes affect the behavior of the chef-client program when run
 * `node['chef_client']['log_dir']` - Sets directory used in
   `Chef::Config[:log_location]` via command-line option to a location
   where chef-client should log output. Default "/var/log/chef".
+* `node['chef_client']['log_dir_mode']` - Sets permissions for the log directory. Default 00750.
 * `node['chef_client']['log_rotation']['options']` - Set options to logrotation of chef-client log file. Default `['compress']`.
 * `node['chef_client']['log_rotation']['postrotate']` - Set postrotate action for chef-client logrotation. Default to chef-client service reload depending on init system.
 * `node['chef_client']['conf_dir']` - Sets directory used via

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,6 +47,7 @@ default['chef_client']['bin']         = '/usr/bin/chef-client'
 # Set a sane default log directory location, overriden by specific
 # platforms below.
 default['chef_client']['log_dir']     = '/var/log/chef'
+default['chef_client']['log_dir_mode'] = 00750
 
 # Configuration for chef-client::cron recipe.
 default['chef_client']['cron'] = {

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -96,7 +96,7 @@ module Opscode
           rescue Chef::Exceptions::ResourceNotFound
             directory node['chef_client'][dir] do
               recursive true
-              mode 00750 if dir == 'log_dir'
+              mode node['chef_client']['log_dir_mode'] if dir == 'log_dir'
               owner d_owner
               group d_group
             end


### PR DESCRIPTION
Previously the permissions for `node['chef_client']['log_dir']` were
hardcoded to 00750.
Sometimes it can be helpful for non-root users to view Chef logs,
and at othertimes, users may wish to set log_dir to /var/log.

In both cases it can be useful to allow the easy changing of mode
for this directory. This change permits it via an attribute.