### PR TITLE
Remove legacy chef-server handling

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,5 +1,8 @@
 driver:
   name: vagrant
+  customize:
+    memory: 1024
+    cpus: 2
 
 provisioner:
   name: chef_zero
@@ -84,3 +87,11 @@ suites:
     chef_client:
       init_style: "init"
       daemon_options: ["-E cook-1951"]
+
+# Testing when we are using chef-client on a Chef Server (12+ only)
+- name: server
+  run_list:
+  - recipe[chef-server]
+  - recipe[chef-client::config]
+  - recipe[chef-client::service]
+  attributes: {}

--- a/Berksfile
+++ b/Berksfile
@@ -1,8 +1,9 @@
-source "https://supermarket.chef.io"
+source 'https://supermarket.chef.io'
 
 metadata
 
 group :integration do
-  cookbook "runit"
-  cookbook "apt"
+  cookbook 'runit'
+  cookbook 'apt'
+  cookbook 'chef-server', '>= 3.0.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 group :unit do
   gem 'berkshelf',  '~> 3.0'
   gem 'chefspec',   '~> 4.1'
-  gem 'fauxhai',    '~>2.2'
+  gem 'fauxhai',    '~>2.3'
 end
 
 group :kitchen_common do

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This cookbook is used to configure a system as a Chef Client.
 
 Requirements
 ------------
-- Chef Client 11.x or better
+- Chef Client [11.6.0](https://www.chef.io/blog/2013/07/23/chef-client-11-6-0-ohai-6-18-0-and-more/) or higher (for use of `node['root_group']` attribute).
 
 ### Platforms
 The following platforms are tested directly under test-kitchen; see .kitchen.yml and TESTING.md for details.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -23,21 +23,6 @@ module Opscode
       include Chef::Mixin::Language if Chef::VERSION < '11.0.0'
       include Chef::DSL::PlatformIntrospection if Chef::VERSION >= '11.0.0'
 
-      def chef_server_user
-        Chef::VERSION >= '11.0.0' ? 'chef_server' : 'chef'
-      end
-
-      def chef_server?
-        if node['platform'] == 'windows'
-          node.recipe?('chef-server')
-        else
-          Chef::Log.debug("Node has Chef Server Recipe? #{node.recipe?("chef-server")}")
-          Chef::Log.debug("Node has Chef Server Executable? #{system("which chef-server > /dev/null 2>&1")}") # ~FC048 Prefer Mixlib::ShellOut is ignored here
-          Chef::Log.debug("Node has Chef Server Ctl Executable? #{system("which chef-server-ctl > /dev/null 2>&1")}") # ~FC048 Prefer Mixlib::ShellOut is ignored here
-          node.recipe?('chef-server') || system('which chef-server > /dev/null 2>&1') || system('which chef-server-ctl > /dev/null 2>&1') # ~FC048 Prefer Mixlib::ShellOut is ignored here
-        end
-      end
-
       def wmi_property_from_query(wmi_property, wmi_query)
         @wmi = ::WIN32OLE.connect("winmgmts://")
         result = @wmi.ExecQuery(wmi_query)
@@ -57,38 +42,9 @@ module Opscode
         end
       end
 
-      def dir_owner
-        if chef_server?
-          chef_server_user
-        else
-          root_owner
-        end
-      end
-
-      def root_group
-        if %w{ openbsd freebsd mac_os_x mac_os_x_server }.include?(node['platform'])
-          'wheel'
-        elsif ['aix'].include?(node['platform'])
-          'system'
-        elsif ['windows'].include?(node['platform'])
-          wmi_property_from_query(:name, "select * from Win32_Group where SID = 'S-1-5-32-544' AND LocalAccount=TRUE")
-        else
-          'root'
-        end
-      end
-
-      def dir_group
-        if chef_server?
-          chef_server_user
-        else
-          root_group
-        end
-      end
-
       def create_directories
-        # dir_owner and dir_group are not found in the block below.
-        d_owner = dir_owner
-        d_group = dir_group
+        # root_owner is not in scope in the block below.
+        d_owner = root_owner
         %w{run_path cache_path backup_path log_dir conf_dir}.each do |dir|
           # Do not redefine the resource if it exist
           begin
@@ -98,7 +54,7 @@ module Opscode
               recursive true
               mode 00750 if dir == 'log_dir'
               owner d_owner
-              group d_group
+              group node['root_group']
             end
           end
         end

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -68,8 +68,8 @@ end
 
 # We need to set these local variables because the methods aren't
 # available in the Chef::Resource scope
-d_owner = dir_owner
-d_group = dir_group
+d_owner = root_owner
+d_group = node['root_group']
 
 template "#{node["chef_client"]["conf_dir"]}/client.rb" do
   source 'client.rb.erb'

--- a/recipes/delete_validation.rb
+++ b/recipes/delete_validation.rb
@@ -21,10 +21,8 @@ class ::Chef::Recipe
   include ::Opscode::ChefClient::Helpers
 end
 
-unless chef_server?
-  file Chef::Config[:validation_key] do
-    action :delete
-    backup false
-    only_if { ::File.exists?(Chef::Config[:client_key]) }
-  end
+file Chef::Config[:validation_key] do
+  action :delete
+  backup false
+  only_if { ::File.exists?(Chef::Config[:client_key]) }
 end

--- a/spec/unit/cron_spec.rb
+++ b/spec/unit/cron_spec.rb
@@ -3,7 +3,10 @@ require 'spec_helper'
 describe 'chef-client::cron' do
 
   let(:chef_run) do
-    ChefSpec::ServerRunner.new.converge(described_recipe)
+    ChefSpec::ServerRunner.new do |node|
+      # the root_group attribute isn't present in fauxhai data
+      node.set['root_group'] = 'root'
+    end.converge(described_recipe)
   end
 
   [
@@ -37,7 +40,7 @@ describe 'chef-client::cron' do
   end
 
   context 'append to log file' do
-  
+
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
         node.set['chef_client']['cron']['append_log'] = true

--- a/spec/unit/resource_cloning_spec.rb
+++ b/spec/unit/resource_cloning_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'chef-client::_unit_test_cloning_resource' do
   let(:chef_run) do
-    chef_run = ChefSpec::ServerRunner.new(platform: 'centos', version: '5.10')
+    chef_run = ChefSpec::ServerRunner.new(platform: 'centos', version: '5.10') do |node|
+      node.set['root_group'] = 'root'
+    end
     chef_run.converge(described_recipe)
   end
 
@@ -10,10 +12,10 @@ describe 'chef-client::_unit_test_cloning_resource' do
     expect(chef_run).to create_directory('/etc/chef').with_owner('fake')
     expect(chef_run).to create_directory('/etc/chef').with_group('fake')
   end
-  
+
   it 'Create Directory with real value, when not exist' do
     expect(chef_run).to create_directory('/var/log/chef').with_owner('root')
     expect(chef_run).to create_directory('/var/log/chef').with_group('root')
   end
-  
+
 end

--- a/test/integration/server/serverspec/server12_spec.rb
+++ b/test/integration/server/serverspec/server12_spec.rb
@@ -1,0 +1,27 @@
+require 'serverspec'
+
+set :backend, :exec
+
+describe 'chef-server-directories' do
+  describe file('/etc/opscode') do
+    it { should be_directory }
+    it { should be_owned_by 'root' }
+  end
+
+  describe file('/etc/opscode-analytics') do
+    it { should be_directory }
+    it { should be_owned_by 'opscode' }
+    it { should be_grouped_into 'opscode' }
+  end
+
+  describe file('/var/log/opscode') do
+    it { should be_directory }
+    it { should be_owned_by 'opscode' }
+    it { should be_grouped_into 'opscode' }
+  end
+
+  describe file('/var/opt/opscode') do
+    it { should be_directory }
+    it { should be_owned_by 'root' }
+  end
+end


### PR DESCRIPTION
This commit merges #253, which resolves the following issues or PR's:

- Closes #196
- Closes #203
- Closes #259

It assumes Chef Server 12 for testing, but should work on systems that are running Chef Server 11 or Enterprise/Private Chef as those products are self-contained and don't have files in the directories managed by the recipes in question in this cookbook (namely config, but handled through the helper library to create directories).

I'd like to know if this works for the folks who have been involved in
those various issues/pull requests, so mentioning here:

@BackSlasher, @dwradcliffe, @juliandunn, @afiune, @binamov, @JeanMertz, @cwebberOps, @hatchetation, @jblaine, @BarthV, @gplessis @caquino, @justindossey, @ikurochkin