### PR TITLE
Introduce 'dir_owner' and 'dir_group' attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ The following attributes affect the behavior of the chef-client program when run
 * `node['chef_client']['log_dir']` - Sets directory used in
   `Chef::Config[:log_location]` via command-line option to a location
   where chef-client should log output. Default "/var/log/chef".
+* `node["chef_client"]["dir_owner"]` - Sets owner for log and
+  configuration directories. Default is nil, means set automatically.
+* `node["chef_client"]["dir_group"]` - Sets group for log and
+  configuration directories. Default is nil, means set automatically.
 * `node['chef_client']['log_rotation']['options']` - Set options to logrotation of chef-client log file. Default `['compress']`.
 * `node['chef_client']['log_rotation']['postrotate']` - Set postrotate action for chef-client logrotation. Default to chef-client service reload depending on init system.
 * `node['chef_client']['conf_dir']` - Sets directory used via

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,6 +46,11 @@ default['chef_client']['bin']         = '/usr/bin/chef-client'
 # platforms below.
 default['chef_client']['log_dir']     = '/var/log/chef'
 
+# Dir owner and group will be set automatically based on server flavor if not
+# customized in attributes
+default['chef_client']['dir_owner']   = nil
+default['chef_client']['dir_group']   = nil
+
 # Configuration for chef-client::cron recipe.
 default['chef_client']['cron'] = {
   'minute' => '0',

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -58,6 +58,8 @@ module Opscode
       end
 
       def dir_owner
+        return node['chef_client']['dir_owner'] if node['chef_client']['dir_owner']
+
         if chef_server?
           chef_server_user
         else
@@ -66,6 +68,8 @@ module Opscode
       end
 
       def root_group
+        return node['chef_client']['dir_group'] if node['chef_client']['dir_group']
+
         if %w{ openbsd freebsd mac_os_x mac_os_x_server }.include?(node['platform'])
           'wheel'
         elsif ['aix'].include?(node['platform'])

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -3,7 +3,10 @@ require 'spec_helper'
 describe 'chef-client::config' do
 
   let(:chef_run) do
-    ChefSpec::ServerRunner.new.converge(described_recipe)
+    ChefSpec::ServerRunner.new do |node|
+      node.set['chef_client']['dir_owner'] = 'foo-owner'
+      node.set['chef_client']['dir_group'] = 'foo-group'
+    end.converge(described_recipe)
   end
 
   it 'contains the default chef_server_url setting' do
@@ -25,7 +28,10 @@ describe 'chef-client::config' do
     '/etc/chef/client.d'
   ].each do |dir|
     it "contains #{dir} directory" do
-      expect(chef_run).to create_directory(dir)
+      expect(chef_run).to create_directory(dir).with(
+        user: 'foo-owner',
+        group: 'foo-group'
+      )
     end
   end
 


### PR DESCRIPTION
Recipe chef-client::config tries to set file ownership to user 'chef_server' returned by helper method 'chef_server_user' on Chef 12, which does not exist on our Chef servers. Talked to a support engineer, he mentioned this could be a edge-case bug. This change is to give user flexibility to customize the owner and group.