### PR TITLE
Add support for specifying gem source for config.

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -60,6 +60,7 @@ node['chef_client']['load_gems'].each do |gem_name, gem_info_hash|
   gem_info_hash ||= {}
   chef_gem gem_name do
     action gem_info_hash[:action] || :install
+    source gem_info_hash[:source] if gem_info_hash[:source]
     version gem_info_hash[:version] if gem_info_hash[:version]
     options ( gem_info_hash[:options] ) if gem_info_hash[:options]
   end


### PR DESCRIPTION
For us poor folks that are behind the corporate veil we need ability to
not hit a gem server for core gems such as chef-vault, chef-reporting
and chef-sugar.