### PR TITLE
Updating client.rb.erb to support adding audit_mode :enabled as an attribute

### DIFF
--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -11,7 +11,7 @@ end
 <% @chef_config.keys.sort.each do |option| -%>
   <% next if %w{ node_name environment exception_handlers report_handlers start_handlers http_proxy https_proxy no_proxy }.include?(option) -%>
   <% case option -%>
-  <% when 'log_level', 'ssl_verify_mode' -%>
+  <% when 'log_level', 'ssl_verify_mode', 'audit_mode' -%>
 <%= option %> <%= @chef_config[option].gsub(/^:/, '').to_sym.inspect %>
   <% when 'log_location' -%>
 <%= option %> <%= @chef_config[option] %>


### PR DESCRIPTION
The current version of the cookbook does not convert :enabled into a ruby symbol, which breaks the client.rb config...

```
[root@ip-172-31-22-68 ~]# cat /etc/chef/client.rb
audit_mode ":enabled"
chef_server_url "https://127.0.0.1/organizations/analytics-workshop"
log_location STDOUT
```

This fix creates the 'audit_mode :enabled' correct as shown:

```
 - update content in file /etc/chef/client.rb from none to 2a6e34
           --- /etc/chef/client.rb	2015-03-19 21:15:40.959129067 +0000
           +++ /tmp/chef-rendered-template20150319-2411-17rcf8y	2015-03-19 21:15:40.958128567 +0000
           @@ -1 +1,13 @@
           +audit_mode :enabled
           +chef_server_url "http://localhost:8889"
           +log_location '/var/log/chef/client.log'
           +validation_client_name "chef-validator"
           +verify_api_cert true
           +node_name "config-centos-66"
           +
           +
           +
           +Dir.glob(File.join("/etc/chef", "client.d", "*.rb")).each do |conf|
           +  Chef::Config.from_file(conf)

           - change mode from '' to '0644'
           - change owner from '' to 'root'


         * ruby_block[reload_client_config] action create
           - execute the ruby block reload_client_config

           - create new directory /etc/chef/client.d
           - change mode from '' to '0755'
           - change owner from '' to 'root'



       Starting audit phase
       Auditing complete
```