### PR TITLE
Cron in chef-client cookbook ignores daemon_options

### DIFF
--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -80,7 +80,7 @@ log_file   = node['chef_client']['cron']['log_file']
 append_log = node['chef_client']['cron']['append_log'] ? '>>' : '>'
 
 # Use daemon_options in cron.
-client_bin << " #{node["chef_client"]["daemon_options"].join(' ')}"
+client_bin << " #{node["chef_client"]["daemon_options"].join(' ')}" if node["chef_client"]["daemon_options"].any?
 
 # If "use_cron_d" is set to true, delete the cron entry that uses the cron
 # resource built in to Chef and instead use the cron_d LWRP.

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -79,6 +79,9 @@ env        = node['chef_client']['cron']['environment_variables']
 log_file   = node['chef_client']['cron']['log_file']
 append_log = node['chef_client']['cron']['append_log'] ? '>>' : '>'
 
+# Use daemon_options in cron.
+client_bin << " #{node["chef_client"]["daemon_options"].join(' ')}"
+
 # If "use_cron_d" is set to true, delete the cron entry that uses the cron
 # resource built in to Chef and instead use the cron_d LWRP.
 if node['chef_client']['cron']['use_cron_d']


### PR DESCRIPTION
The cron functionality ignores the daemon_options attribute, this will add the daemon_option to the cronjob.