### PR TITLE
Fix delete_validation.rb exception bug when node['chef-client']['config']['validation_key']` is nil

### DIFF
--- a/recipes/delete_validation.rb
+++ b/recipes/delete_validation.rb
@@ -25,9 +25,6 @@ unless Chef::Config[:validation_key].nil?
   file Chef::Config[:validation_key] do
     action :delete
     backup false
-    only_if {
-      ::File.exists?(Chef::Config[:validation_key]) &&
-      ::File.exists?(Chef::Config[:client_key])
-    }
+    only_if { ::File.exists?(Chef::Config[:client_key]) }
   end
 end

--- a/recipes/delete_validation.rb
+++ b/recipes/delete_validation.rb
@@ -21,8 +21,13 @@ class ::Chef::Recipe
   include ::Opscode::ChefClient::Helpers
 end
 
-file Chef::Config[:validation_key] do
-  action :delete
-  backup false
-  only_if { ::File.exists?(Chef::Config[:client_key]) }
+unless Chef::Config[:validation_key].nil?
+  file Chef::Config[:validation_key] do
+    action :delete
+    backup false
+    only_if {
+      ::File.exists?(Chef::Config[:validation_key]) &&
+      ::File.exists?(Chef::Config[:client_key])
+    }
+  end
 end


### PR DESCRIPTION
Fixes a bug where provisioning with chef_zero results in a nil value for the `node['chef-client']['config']['validation_key']` attribute, causing the file resource to be looking at a blank name and hence raising an exception.

See https://github.com/opscode-cookbooks/chef-client/issues/307