### PR TITLE
Replace missing root_group with node var in service recipes

### DIFF
--- a/recipes/bluepill_service.rb
+++ b/recipes/bluepill_service.rb
@@ -9,7 +9,7 @@ Chef::Log.debug("Found chef-client in #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_directories
 
-group = root_group
+group = node['root_group']
 
 directory node['chef_client']['run_path'] do
   recursive true

--- a/recipes/daemontools_service.rb
+++ b/recipes/daemontools_service.rb
@@ -9,7 +9,7 @@ Chef::Log.debug("Found chef-client in #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_directories
 
-group = root_group
+group = node['root_group']
 
 include_recipe 'daemontools' # ~FC007: daemontools is only required when using the daemontools_service recipe 
 


### PR DESCRIPTION
deamontools_service and bluepill_service still use the `root_group` variable, which was removed in favour of a node attribute.

Using these without this change fails to converge. Probably there should be some tests for these recipes. ;-)