### PR TITLE
Fix log_location regex possibility bug.

### DIFF
--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -14,7 +14,7 @@ end
   <% when 'log_level', 'ssl_verify_mode', 'audit_mode' -%>
 <%= option %> <%= @chef_config[option].gsub(/^:/, '').to_sym.inspect %>
   <% when 'log_location' -%>
-<%= option %> <%= @chef_config[option] %>
+<%= option %> "<%= @chef_config[option] %>"
   <% else -%>
 <%= option %> <%= @chef_config[option].inspect %>
   <% end -%>

--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -14,7 +14,11 @@ end
   <% when 'log_level', 'ssl_verify_mode', 'audit_mode' -%>
 <%= option %> <%= @chef_config[option].gsub(/^:/, '').to_sym.inspect %>
   <% when 'log_location' -%>
-<%= option %> "<%= @chef_config[option] %>"
+  <%   if @chef_config[option].instance_of? String -%>
+<%= option %> <%= @chef_config[option].inspect %>
+  <%   else -%>
+<%= option %> <%= @chef_config[option] -%>
+  <%   end -%>
   <% else -%>
 <%= option %> <%= @chef_config[option].inspect %>
   <% end -%>


### PR DESCRIPTION
log_location must be wrapped in quotes or *nix values will be seen as regexs and completely break chef-client.