### PR TITLE
Support interval and splay on Windows

### DIFF
--- a/recipes/windows_service.rb
+++ b/recipes/windows_service.rb
@@ -29,8 +29,19 @@ end
 # libraries/helpers.rb method to DRY directory creation resources
 create_directories
 
+d_owner = root_owner
+d_group = node['root_group']
+
+template "#{node["chef_client"]["conf_dir"]}/client.service.rb" do
+  source 'client.service.rb.erb'
+  owner d_owner
+  group d_group
+  mode 00644
+end
+
 execute 'register-chef-service' do
-  command "chef-service-manager -a install -L #{File.join(node['chef_client']['log_dir'], 'client.log')}"
+  command "chef-service-manager -a install -c #{File.join(node['chef_client']['conf_dir'], 'client.service.rb')} "\
+    "-L #{File.join(node['chef_client']['log_dir'], 'client.log')}"
   not_if { chef_client_service_running }
 end
 

--- a/templates/windows/client.service.rb.erb
+++ b/templates/windows/client.service.rb.erb
@@ -1,0 +1,11 @@
+if File.exists?(%q|<%= node["chef_client"]["conf_dir"] %>/client.rb|)
+   Chef::Config.from_file(%q|<%= node["chef_client"]["conf_dir"] %>/client.rb|)
+end
+
+<% unless node["chef_client"]["interval"].nil? -%>
+interval <%= node["chef_client"]["interval"] %>
+<% end -%>
+
+<% unless node["chef_client"]["splay"].nil? -%>
+splay <%= node["chef_client"]["splay"] %>
+<% end -%>


### PR DESCRIPTION
This is the simplest fix I can think of for #235 while not making chef/chef#3432 an issue. We can also make better guarantees around idempotence if we're just modifying a file (the service manager currently only checks if the service is installed, which is quite incorrect as you could modify the interval in your cookbook and nothing would change) This fix involves no changes to chef client so it will work with any versions of chef this cookbook already works with. One issue I did find with chef client was that the service manager appends -L with a default value if you don't specify it, which means we cannot put the log location in `client.service.rb`.

cc @jeremiahsnapp @smurawski @juliandunn 