### PR TITLE
Avoid double quotes based on changes for issue #317. Fixes issue #321

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -29,7 +29,7 @@ end
 
 if node['chef_client']['log_file'].is_a? String and node['chef_client']['init_style'] != 'runit'
   log_path = File.join(node['chef_client']['log_dir'], node['chef_client']['log_file'])
-  node.default['chef_client']['config']['log_location'] = "#{log_path}"
+  node.default['chef_client']['config']['log_location'] = log_path
 
   case node['platform_family']
   when 'rhel', 'debian', 'fedora'

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -29,7 +29,7 @@ end
 
 if node['chef_client']['log_file'].is_a? String and node['chef_client']['init_style'] != 'runit'
   log_path = File.join(node['chef_client']['log_dir'], node['chef_client']['log_file'])
-  node.default['chef_client']['config']['log_location'] = "'#{log_path}'"
+  node.default['chef_client']['config']['log_location'] = "#{log_path}"
 
   case node['platform_family']
   when 'rhel', 'debian', 'fedora'


### PR DESCRIPTION
Tested with chef-client 12.4.1 on CentOS 6.6 and Windows 2012r2 nodes