### PR TITLE
skip these properties, otherwise they get duplicated

### DIFF
--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -9,7 +9,7 @@ end
 
 <% end -%>
 <% @chef_config.keys.sort.each do |option| -%>
-  <% next if %w{ node_name exception_handlers report_handlers start_handlers }.include?(option) -%>
+  <% next if %w{ node_name exception_handlers report_handlers start_handlers http_proxy https_proxy no_proxy }.include?(option) -%>
   <% case option -%>
   <% when 'log_level', 'ssl_verify_mode', 'audit_mode' -%>
 <%= option %> <%= @chef_config[option].gsub(/^:/, '').to_sym.inspect %>


### PR DESCRIPTION
the `http_proxy` and `https_proxy` variables get duplicated in the chef-client config otherwise.

adding back in #269 , verified it works internally. 
