### PR TITLE
added check for nil attributes for windows_task creds

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -61,8 +61,8 @@ default['chef_client']['cron'] = {
 # Configuration for Windows scheduled task
 default['chef_client']['task']['frequency'] = 'minute'
 default['chef_client']['task']['frequency_modifier'] = node['chef_client']['interval'].to_i / 60
-default['chef_client']['task']['user'] = 'SYSTEM'
-default['chef_client']['task']['password'] = nil #Password is only required for none system users
+default['chef_client']['task']['user'] = nil
+default['chef_client']['task']['password'] = nil
 
 default['chef_client']['load_gems'] = {}
 

--- a/recipes/task.rb
+++ b/recipes/task.rb
@@ -35,8 +35,8 @@ windows_task 'chef-client' do
   -L #{File.join(node['chef_client']['log_dir'], 'client.log')} \
   -c #{File.join(node['chef_client']['conf_dir'], 'client.rb')} -s #{node['chef_client']['splay']} > NUL 2>&1'"
 
-  user               node['chef_client']['task']['user']
-  password           node['chef_client']['task']['password']
+  user               node['chef_client']['task']['user'] if node['chef_client']['task']['user']
+  password           node['chef_client']['task']['password'] if node['chef_client']['task']['password']
   frequency          node['chef_client']['task']['frequency'].to_sym
   frequency_modifier node['chef_client']['task']['frequency_modifier']
   start_time         node['chef_client']['task']['start_time'] || start_time


### PR DESCRIPTION
Since windows_task will by default use the SYSTEM account, we can change the attributes to nil.
This will avoid having to specify a password for the SYSTEM account.

I believe this fixes #178